### PR TITLE
Update go mod files to work with 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/stretchr/testify v1.6.1
 	go.temporal.io/sdk v1.0.0
+	google.golang.org/grpc v1.32.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d h1:L/IKR6COd7ubZrs2oTnTi73IhgqJ71c9s80WsQnh0Es=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
While trying to run the tests I got the following message

```
../go/pkg/mod/google.golang.org/grpc@v1.32.0/internal/channelz/types_linux.go:24:2: missing go.sum entry for module providing package golang.org/x/sys/unix (imported by google.golang.org/grpc/internal/channelz); to add:
        go get google.golang.org/grpc/internal/channelz@v1.32.0
```

## Why?
<!-- Tell your future self why have you made these changes -->
To help others avoid the error

## Checklist
1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
`go test ./...`
