### PR TITLE
Fix worker deadline exceeded

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -18,7 +18,11 @@ func TransferMoney(ctx workflow.Context, transferDetails TransferDetails) error 
 	}
 	options := workflow.ActivityOptions{
 		// Timeout options specify when to automatically timeout Activity functions.
-		StartToCloseTimeout: time.Minute,
+		//
+		// The activity deadline is computed as the more recent of the StartToClose
+		// and ScheduleToClose deadlines.
+		StartToCloseTimeout:    time.Minute,
+		ScheduleToCloseTimeout: time.Minute,
 		// Optionally provide a customized RetryPolicy.
 		// Temporal retries failures by default, this is just an example.
 		RetryPolicy: retrypolicy,
@@ -34,4 +38,5 @@ func TransferMoney(ctx workflow.Context, transferDetails TransferDetails) error 
 	}
 	return nil
 }
+
 // @@@SNIPEND


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Ensures both the scheduled to close and start to close timeouts are set.

Before this fix, the more [recent of the two deadlines](https://github.com/temporalio/sdk-go/blob/master/internal/activity.go#L235) is used as the activity deadline.

Since the schedule to close timeout is unset, it defaults to a 0 duration. This results
in the scheduled time + 0 being more recent than the start time + 1m, and causes the
worker to immediately error due to the deadline being exceeded.

## Why?
To fix a worker timeout bug.

## Checklist

1. Closes #12

2. How was this tested: Tested locally.

3. Any docs updates needed? No
