### PR TITLE
Update to use new MoneyTransfer code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a simple project for demonstrating Temporal with the Go SDK.
 
-The full 20 minute guide is here: https://learn.temporal.io/getting_started/go/first_program_in_go/
+The full 20-minute tutorial is here: https://learn.temporal.io/getting_started/go/first_program_in_go/
 
 ## Basic instructions
 
@@ -16,9 +16,9 @@ cd  docker-compose
 docker-compose up
 ```
 
-Leave it running. You can use the Temporal Web UI at [localhost:8080](localhost:8080) which is currently in Beta. To use the legacy Temporal Web UI, use the [localhost:8088](localhost:8088) URL. There should be no workflows visible in the dashboard right now.
+Leave it running. You can use the Temporal Web UI at [localhost:8080](localhost:8080) which is currently in Beta. To use the legacy Temporal Web UI, use the [localhost:8088](localhost:8088) URL instead. There should be no workflows visible in the dashboard right now.
 
-### Step 1: Clone this repo
+### Step 1: Clone this Repository
 
 In another terminal instance, clone this repo and run this application.
 
@@ -43,7 +43,7 @@ In YET ANOTHER terminal instance, run the worker. Notice that this worker hosts 
 go run worker/main.go
 ```
 
-Now you can see the workflow run to completion. You can also see the worker polling for workflows and activities in the task queue at [http://localhost:8088/namespaces/default/task-queues/TRANSFER_MONEY_TASK_QUEUE](http://localhost:8088/namespaces/default/task-queues/TRANSFER_MONEY_TASK_QUEUE).
+Now you can see the workflow run to completion. You can also see the worker polling for workflows and activities in the task queue at [http://localhost:8080/namespaces/default/task-queues/TRANSFER_MONEY_TASK_QUEUE](http://localhost:8080/namespaces/default/task-queues/TRANSFER_MONEY_TASK_QUEUE).
 
 <img width="882" alt="CleanShot 2021-07-20 at 17 48 45@2x" src="https://user-images.githubusercontent.com/6764957/126413160-18663430-bb7a-4d3a-874e-80598e1fa07d.png">
 

--- a/activity.go
+++ b/activity.go
@@ -2,33 +2,32 @@ package app
 
 import (
 	"context"
-	"fmt"
 )
 
 // @@@SNIPSTART money-transfer-project-template-go-activity-withdraw
-func Withdraw(ctx context.Context, transferDetails TransferDetails) error {
-	fmt.Printf(
-		"\nWithdrawing $%f from account %s. ReferenceId: %s\n",
-		transferDetails.Amount,
-		transferDetails.FromAccount,
-		transferDetails.ReferenceID,
-	)
-	return nil
+func Withdraw(ctx context.Context, data PaymentDetails) (string, error) {
+	bank := BankingService{"bank-api.example.com"}
+	confirmation, err := bank.Withdraw(data.SourceAccount, data.Amount)
+	if err != nil {
+		return "", err
+	}
+
+	return confirmation, nil
 }
 
 // @@@SNIPEND
 
 // @@@SNIPSTART money-transfer-project-template-go-activity-deposit
-func Deposit(ctx context.Context, transferDetails TransferDetails) error {
-	fmt.Printf(
-		"\nDepositing $%f into account %s. ReferenceId: %s\n",
-		transferDetails.Amount,
-		transferDetails.ToAccount,
-		transferDetails.ReferenceID,
-	)
-	// Switch out comments on the return statements to simulate an error
-	//return fmt.Errorf("deposit did not occur due to an issue")
-	return nil
+func Deposit(ctx context.Context, data PaymentDetails) (string, error) {
+	bank := BankingService{"bank-api.example.com"}
+	// Uncomment the next line and comment the one after that to simulate failure
+	// confirmation, err := bank.DepositThatFails(data.TargetAccount, data.Amount)
+	confirmation, err := bank.Deposit(data.TargetAccount, data.Amount)
+	if err != nil {
+		return "", err
+	}
+
+	return confirmation, nil
 }
 
 // @@@SNIPEND

--- a/activity.go
+++ b/activity.go
@@ -2,10 +2,16 @@ package app
 
 import (
 	"context"
+	"log"
 )
 
 // @@@SNIPSTART money-transfer-project-template-go-activity-withdraw
 func Withdraw(ctx context.Context, data PaymentDetails) (string, error) {
+	log.Printf(
+		"Withdrawing $%d from account %s.\n\n",
+		data.Amount,
+		data.SourceAccount,
+	)
 	bank := BankingService{"bank-api.example.com"}
 	confirmation, err := bank.Withdraw(data.SourceAccount, data.Amount)
 	return confirmation, err
@@ -15,6 +21,11 @@ func Withdraw(ctx context.Context, data PaymentDetails) (string, error) {
 
 // @@@SNIPSTART money-transfer-project-template-go-activity-deposit
 func Deposit(ctx context.Context, data PaymentDetails) (string, error) {
+	log.Printf(
+		"Depositing $%d into account %s.\n\n",
+		data.Amount,
+		data.TargetAccount,
+	)
 	bank := BankingService{"bank-api.example.com"}
 	// Uncomment the next line and comment the one after that to simulate failure
 	// confirmation, err := bank.DepositThatFails(data.TargetAccount, data.Amount)

--- a/activity.go
+++ b/activity.go
@@ -8,11 +8,7 @@ import (
 func Withdraw(ctx context.Context, data PaymentDetails) (string, error) {
 	bank := BankingService{"bank-api.example.com"}
 	confirmation, err := bank.Withdraw(data.SourceAccount, data.Amount)
-	if err != nil {
-		return "", err
-	}
-
-	return confirmation, nil
+	return confirmation, err
 }
 
 // @@@SNIPEND
@@ -23,11 +19,7 @@ func Deposit(ctx context.Context, data PaymentDetails) (string, error) {
 	// Uncomment the next line and comment the one after that to simulate failure
 	// confirmation, err := bank.DepositThatFails(data.TargetAccount, data.Amount)
 	confirmation, err := bank.Deposit(data.TargetAccount, data.Amount)
-	if err != nil {
-		return "", err
-	}
-
-	return confirmation, nil
+	return confirmation, err
 }
 
 // @@@SNIPEND

--- a/banking-client.go
+++ b/banking-client.go
@@ -17,18 +17,18 @@ type BankingService struct {
 }
 
 func (client BankingService) Withdraw(accountNum string, amount int) (string, error) {
-	return generateTranactionId("W", 10), nil
+	return generateTransactionId("W", 10), nil
 }
 
 func (client BankingService) Deposit(accountNum string, amount int) (string, error) {
-	return generateTranactionId("D", 10), nil
+	return generateTransactionId("D", 10), nil
 }
 
 func (client BankingService) DepositThatFails(accountNum string, amount int) (string, error) {
 	return "", errors.New("This deposit has failed.")
 }
 
-func generateTranactionId(prefix string, length int) string {
+func generateTransactionId(prefix string, length int) string {
 	randChars := make([]byte, length)
 	for i := range randChars {
 		allowedChars := "0123456789"

--- a/banking-client.go
+++ b/banking-client.go
@@ -1,0 +1,38 @@
+package app
+
+// This code simulates a client for a hypothetical banking service.
+// It supports both withdrawals and deposits, and generates a
+// pseudorandom transaction ID for each request. Tip: You can
+// modify these functions to introduce delays or errors, allowing
+// you to experiment with failures and timeouts.
+import (
+	"errors"
+	"math/rand"
+)
+
+type BankingService struct {
+	// the hostname is to make it more realistic. This code does not
+	// actually make any network calls.
+	Hostname string
+}
+
+func (client BankingService) Withdraw(accountNum string, amount int) (string, error) {
+	return generateTranactionId("W", 10), nil
+}
+
+func (client BankingService) Deposit(accountNum string, amount int) (string, error) {
+	return generateTranactionId("D", 10), nil
+}
+
+func (client BankingService) DepositThatFails(accountNum string, amount int) (string, error) {
+	return "", errors.New("This deposit has failed.")
+}
+
+func generateTranactionId(prefix string, length int) string {
+	randChars := make([]byte, length)
+	for i := range randChars {
+		allowedChars := "0123456789"
+		randChars[i] = allowedChars[rand.Intn(len(allowedChars))]
+	}
+	return prefix + string(randChars)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module money-transfer-project-template-go/app
 go 1.16
 
 require (
-	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.8.0
 	go.temporal.io/sdk v1.16.0
 )

--- a/shared.go
+++ b/shared.go
@@ -1,16 +1,15 @@
 package app
 
 // @@@SNIPSTART money-transfer-project-template-go-shared-task-queue
-const TransferMoneyTaskQueue = "TRANSFER_MONEY_TASK_QUEUE"
+const MoneyTransferTaskQueueName = "TRANSFER_MONEY_TASK_QUEUE"
 
 // @@@SNIPEND
 
 // @@@SNIPSTART money-transfer-project-template-go-transferdetails
-type TransferDetails struct {
-	Amount      float32
-	FromAccount string
-	ToAccount   string
-	ReferenceID string
+type PaymentDetails struct {
+	SourceAccount string
+	TargetAccount string
+	Amount        int
 }
 
 // @@@SNIPEND

--- a/start/main.go
+++ b/start/main.go
@@ -29,10 +29,14 @@ func main() {
 		Amount:        250,
 	}
 
+	log.Printf("Starting transfer from account %s to account %s for %d", input.SourceAccount, input.TargetAccount, input.Amount)
+
 	we, err := c.ExecuteWorkflow(context.Background(), options, app.MoneyTransfer, input)
 	if err != nil {
 		log.Fatalln("unable to start the Workflow", err)
 	}
+
+	log.Printf("WorkflowID: %s RunID: %s\n", we.GetID(), we.GetRunID())
 
 	var result string
 	err = we.Get(context.Background(), &result)

--- a/start/main.go
+++ b/start/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 
-	"github.com/google/uuid"
 	"go.temporal.io/sdk/client"
 
 	"money-transfer-project-template-go/app"
@@ -13,40 +12,34 @@ import (
 // @@@SNIPSTART money-transfer-project-template-go-start-workflow
 func main() {
 	// Create the client object just once per process
-	c, err := client.NewClient(client.Options{})
+	c, err := client.Dial(client.Options{})
 	if err != nil {
 		log.Fatalln("unable to create Temporal client", err)
 	}
 	defer c.Close()
-	options := client.StartWorkflowOptions{
-		ID:        "transfer-money-workflow",
-		TaskQueue: app.TransferMoneyTaskQueue,
-	}
-	transferDetails := app.TransferDetails{
-		Amount:      54.99,
-		FromAccount: "001-001",
-		ToAccount:   "002-002",
-		ReferenceID: uuid.New().String(),
-	}
-	we, err := c.ExecuteWorkflow(context.Background(), options, app.TransferMoney, transferDetails)
-	if err != nil {
-		log.Fatalln("error starting TransferMoney workflow", err)
-	}
-	printResults(transferDetails, we.GetID(), we.GetRunID())
-}
-// @@@SNIPEND
 
-func printResults(transferDetails app.TransferDetails, workflowID, runID string) {
-	log.Printf(
-		"\nTransfer of $%f from account %s to account %s is processing. ReferenceID: %s\n",
-		transferDetails.Amount,
-		transferDetails.FromAccount,
-		transferDetails.ToAccount,
-		transferDetails.ReferenceID,
-	)
-	log.Printf(
-		"\nWorkflowID: %s RunID: %s\n",
-		workflowID,
-		runID,
-	)
+	options := client.StartWorkflowOptions{
+		ID:        "pay-invoice-701",
+		TaskQueue: app.MoneyTransferTaskQueueName,
+	}
+
+	input := app.PaymentDetails{
+		SourceAccount: "85-150",
+		TargetAccount: "43-812",
+		Amount:        250,
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), options, app.MoneyTransfer, input)
+	if err != nil {
+		log.Fatalln("unable to start the Workflow", err)
+	}
+
+	var result string
+	err = we.Get(context.Background(), &result)
+	if err != nil {
+		log.Fatalln("unable to get Workflow result", err)
+	}
+	log.Println(result)
 }
+
+// @@@SNIPEND

--- a/worker/main.go
+++ b/worker/main.go
@@ -12,20 +12,24 @@ import (
 // @@@SNIPSTART money-transfer-project-template-go-worker
 func main() {
 	// Create the client object just once per process
-	c, err := client.NewClient(client.Options{})
+	c, err := client.Dial(client.Options{})
 	if err != nil {
 		log.Fatalln("unable to create Temporal client", err)
 	}
 	defer c.Close()
+
+	w := worker.New(c, app.MoneyTransferTaskQueueName, worker.Options{})
+
 	// This worker hosts both Workflow and Activity functions
-	w := worker.New(c, app.TransferMoneyTaskQueue, worker.Options{})
-	w.RegisterWorkflow(app.TransferMoney)
+	w.RegisterWorkflow(app.MoneyTransfer)
 	w.RegisterActivity(app.Withdraw)
 	w.RegisterActivity(app.Deposit)
+
 	// Start listening to the Task Queue
 	err = w.Run(worker.InterruptCh())
 	if err != nil {
 		log.Fatalln("unable to start Worker", err)
 	}
 }
+
 // @@@SNIPEND

--- a/workflow.go
+++ b/workflow.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"time"
 
 	"go.temporal.io/sdk/temporal"
@@ -8,7 +9,7 @@ import (
 )
 
 // @@@SNIPSTART money-transfer-project-template-go-workflow
-func TransferMoney(ctx workflow.Context, transferDetails TransferDetails) error {
+func MoneyTransfer(ctx workflow.Context, input PaymentDetails) (string, error) {
 	// RetryPolicy specifies how to automatically handle retries if an Activity fails.
 	retrypolicy := &temporal.RetryPolicy{
 		InitialInterval:    time.Second,
@@ -24,15 +25,21 @@ func TransferMoney(ctx workflow.Context, transferDetails TransferDetails) error 
 		RetryPolicy: retrypolicy,
 	}
 	ctx = workflow.WithActivityOptions(ctx, options)
-	err := workflow.ExecuteActivity(ctx, Withdraw, transferDetails).Get(ctx, nil)
+
+	var output1 string
+	err := workflow.ExecuteActivity(ctx, Withdraw, input).Get(ctx, &output1)
 	if err != nil {
-		return err
+		return "", err
 	}
-	err = workflow.ExecuteActivity(ctx, Deposit, transferDetails).Get(ctx, nil)
+
+	var output2 string
+	err = workflow.ExecuteActivity(ctx, Deposit, input).Get(ctx, &output2)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+
+	result := fmt.Sprintf("Transfer complete (transaction IDs: %s, %s)", output1, output2)
+	return result, nil
 }
 
 // @@@SNIPEND

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -12,16 +12,18 @@ import (
 func Test_Workflow(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
+
 	// Mock activity implementation
-	testDetails := TransferDetails{
-		Amount:      1.00,
-		FromAccount: "001-001",
-		ToAccount:   "002-002",
-		ReferenceID: "1234",
+	testDetails := PaymentDetails{
+		SourceAccount: "85-150",
+		TargetAccount: "43-812",
+		Amount:        250,
 	}
-	env.OnActivity(Withdraw, mock.Anything, testDetails).Return(nil)
-	env.OnActivity(Deposit, mock.Anything, testDetails).Return(nil)
-	env.ExecuteWorkflow(TransferMoney, testDetails)
+
+	env.OnActivity(Withdraw, mock.Anything, testDetails).Return("", nil)
+	env.OnActivity(Deposit, mock.Anything, testDetails).Return("", nil)
+
+	env.ExecuteWorkflow(MoneyTransfer, testDetails)
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 }


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
I updated the code to use the new MoneyTransfer scenario, which is based on simulated calls to a remote service. 

I also made a few small edits to the README, for the sake of clarity and to encourage use of the new Web UI. Since I do not (knowingly) have the ability to change the screenshot used in the README, I have attached an updated screenshot here.

## Why?
This is a more realistic example than before and also opens the door for more advanced learners to get creative and experiment with failures and timeouts (by modifying the client to introduce delays or errors when "calling" the hypothetical remote service).

This version also differs from the previous one in that the Activities have return values, which the Workflow accesses to produce its own return value.

Finally, this will make the money transfer code used in this "Run Your First App" tutorial congruent with the code used elsewhere, notably the "How Temporal Works" section of the Temporal website and in the Temporal 101 training.

## Checklist
1. Closes N/A (request was tracked in an internal system)

2. How was this tested:
I followed the instructions in the README (and in the tutorial) using the new code. I also ran `go test` to ensure that the unit test for the Workflow behaved as expected.

3. Any docs updates needed?
I do not think any docs changes will be required. I did my best to maintain the existing SNIPSTART/SNIPEND comments.

The tutorial will need to change to reflect the update. The basic steps remain the same, but code excerpts and screenshots in the tutorial must be updated. Also, the step under the "Recover from an Activity error" heading that describes what to uncomment in order to induce an error will also need to change, since the line to uncomment is now a few lines before the function returns.

![screenshot-poller-for-readme](https://user-images.githubusercontent.com/2183904/190000282-e9383957-382c-4729-bc5d-01b0a242add0.png)

