### PR TITLE
Fix typos in Money Transfer Project for golang

### DIFF
--- a/banking-client.go
+++ b/banking-client.go
@@ -95,7 +95,7 @@ func (client BankingService) Deposit(accountNumber string, amount int, reference
 	return generateTransactionID("D", 10), nil
 }
 
-// DepositThatFails simulates an unknonw error.
+// DepositThatFails simulates an unknown error.
 func (client BankingService) DepositThatFails(accountNumber string, amount int, referenceID string) (string, error) {
 	return "", errors.New("This deposit has failed.")
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -30,7 +30,7 @@ func Test_SuccessfulTransferWorkflow(t *testing.T) {
 	require.NoError(t, env.GetWorkflowError())
 }
 
-func Test_DepostFailedWorkflow(t *testing.T) {
+func Test_DepositFailedWorkflow(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 


### PR DESCRIPTION
Typo fixes.

One of the fixes is the name of a test. I ran the tests both with and without the name change, and confirmed the results were the same. I also searched to see if any other material in the project referenced the incorrectly named test and there were no references.